### PR TITLE
fixes saving of image with spaces in the name

### DIFF
--- a/omero_batch_analysis.py
+++ b/omero_batch_analysis.py
@@ -171,7 +171,7 @@ for imageId in imageIds:
         imp = IJ.getImage();
         path = paths + imp.getTitle() + operation + ".ome.tiff";
         print(path)
-        options = "save=" + path + " export compression=Uncompressed"
+        options = "save=[" + path + "] export compression=Uncompressed"
         IJ.run(imp, "Bio-Formats Exporter", options);
         imp.changes = False
         imp.close()


### PR DESCRIPTION
Hi,
I'm new to the Omero world and your code was a good help to jump in ! 

Nevertheless, @lacan and I realized that when images have blank space(s) within their name , the script bugs BUT it can be solved by adding [ ] around the variable path.

Cheers,

Romain